### PR TITLE
Fix configuration path for LineBotScheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+src/LineBotScheduler/bin/
+src/LineBotScheduler/obj/

--- a/src/LineBotScheduler/LineBotScheduler.csproj
+++ b/src/LineBotScheduler/LineBotScheduler.csproj
@@ -15,4 +15,10 @@
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.14.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/src/LineBotScheduler/Program.cs
+++ b/src/LineBotScheduler/Program.cs
@@ -11,6 +11,7 @@ using Quartz;
 using LineBotScheduler;
 
 var builder = Host.CreateDefaultBuilder(args)
+    .UseContentRoot(AppContext.BaseDirectory)
     .ConfigureServices((context, services) =>
     {
         services.Configure<LineOptions>(context.Configuration.GetSection("Line"));


### PR DESCRIPTION
## Summary
- ensure `appsettings.json` gets copied to the output
- set content root to the executable directory
- add `.gitignore` for build artifacts

## Testing
- `dotnet build src/LineBotScheduler`

------
https://chatgpt.com/codex/tasks/task_e_687a72f257888331939d7ce9cdf08993